### PR TITLE
Remove new-line character from password output.

### DIFF
--- a/src/password-generator.c
+++ b/src/password-generator.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[]) {
   }
 
   // Happy path: print the password!
-  result = printf("%s\n", wrap_printable(buf, password_length));
+  result = printf("%s", wrap_printable(buf, password_length));
   if (result < 0) {
     // There was an output error, no sense trying to print an error message
     retval = 1;


### PR DESCRIPTION
If I want to do something like `password-generator 64 | xclip -selection c` it includes a new-line character in the output, which I don't want. This removes the new line.